### PR TITLE
🔧 Fix: Update banner documentation link to redirect to homepage

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -63,7 +63,7 @@ const config: DocsThemeConfig = {
     text: (
       <a
         className="!text-white hover:!text-white/80"
-        href="/docs"
+        href="/"
         target="_blank"
         rel="noopener noreferrer"
         aria-label="Documentation Status"


### PR DESCRIPTION
Update the documentation banner link to redirect to the homepage (`/`) instead of the non-existent `/docs` route, ensuring proper navigation for users.