### PR TITLE
Fix incorrect tutorial link in smart contract deployment guide

### DIFF
--- a/src/pages/quick-start/get-connected.mdx
+++ b/src/pages/quick-start/get-connected.mdx
@@ -56,4 +56,4 @@ Get testnet Ether (ETH) from these faucets so you can fund your wallet to send t
 Check out faucets [here](/quick-start/faucets). Alternatively, you can [bridge](/quick-start/faucets#bridging-funds-to-ink-sepolia) testnet funds.
 
 ## What Next?
-Check out the [tutorials](/build/tutorials/deploy-a-smart-contract-using/foundry) to learn how to deploy contracts on Ink and more!
+Check out the [tutorials](/build/tutorials/deploying-a-smart-contract/foundry) to learn how to deploy contracts on Ink and more!


### PR DESCRIPTION
## Description
This PR fixes an incorrect URL path in the documentation that was leading to a 404 error.

## Changes
Updated the tutorial link path to the correct location.