### PR TITLE
Fix Grammar and Typos in Documentation Changes Made

### DIFF
--- a/src/pages/build/tutorials/deploying-a-smart-contract/remix.mdx
+++ b/src/pages/build/tutorials/deploying-a-smart-contract/remix.mdx
@@ -43,7 +43,7 @@ contract InkContract {
 
 ## Connecting to INK Network
 
-1. On the left sidebar, click the `Deploy & tun transactions` tab (represented by a deployment arrow icon ▶️)
+1. On the left sidebar, click the `Deploy & run transactions` tab (represented by a deployment arrow icon ▶️)
 2. In the `ENVIRONMENT` dropdown:
    - If you see `Injected Provider`, select it
    - If not visible, click `Customize this list...` in dropdown

--- a/src/pages/build/tutorials/verify-smart-contract.mdx
+++ b/src/pages/build/tutorials/verify-smart-contract.mdx
@@ -45,7 +45,7 @@ Choose the format that applies to your files:
 - Vyper ([Standard JSON input](/build/tutorials/verify-smart-contract#vyper-multi-part-files-and-standard-json-input))
 
 #### Solidity (Flattened source code)
-This verification method is recommended only for single-file smart contract without any imports. For verification of contracts containing more that 1 file, it's recommended to use different verification method.
+This verification method is recommended only for single-file smart contracts without any imports. For verification of contracts containing more than 1 file, it's recommended to use different verification method.
 
 ![Blockscout verification 3](../../../images/blockscout_verif_3_ink.png)
 


### PR DESCRIPTION
File: src/pages/build/tutorials/verify-smart-contract.mdx
1. Changed "contract" to "contracts"
Old: "single-file smart contract without any imports"
New: "single-file smart contracts without any imports"
Reason: Improved grammar consistency as we're referring to contracts in general
2. Changed "that" to "than"
Old: "more that 1 file"
New: "more than 1 file"
Reason: Corrected grammatical error - "than" is the correct word for comparisons
File: src/pages/build/tutorials/deploying-a-smart-contract/remix.mdx
1. Changed "tun" to "run"
Old: "Deploy & tun transactions"
New: "Deploy & run transactions"
Reason: Fixed typo in UI element description to match actual interface text