### PR TITLE
docs: fix link address Update bridges-content.mdx

### DIFF
--- a/src/content/shared/bridges-content.mdx
+++ b/src/content/shared/bridges-content.mdx
@@ -15,7 +15,7 @@ Transaction times vary based on network congestion and gas fees. Please ensure y
 5. Once the bridging is complete the assets will appear in your wallet on Ink.
 
 ## Gelato bridge
-Bridge: http://bridge-gel-sepolia.inkonchain.com/
+Bridge: https://bridge-gel-sepolia.inkonchain.com/
 
 ## Ink Bridge
 Bridge: https://inkonchain.com/bridge


### PR DESCRIPTION
**Gelato bridge URL**:
   - The URL `http://bridge-gel-sepolia.inkonchain.com/` uses `http://`, whereas it's generally better to use `https://` for security purposes.

Corrected.