### PR TITLE
docs: update RPC Page to Reflect Alchemy's Support for Ink Sepolia

### DIFF
--- a/src/pages/tools/rpc.mdx
+++ b/src/pages/tools/rpc.mdx
@@ -9,6 +9,7 @@ Alchemy provides fast and reliable private RPC endpoints alongside a full suite 
 
 **Supported Networks**
 - Ink Mainnet
+- Ink Sepolia
 
 ## [Gelato](https://gelato.network)
 


### PR DESCRIPTION
# Ink-Sepolia RPC Now Available on Alchemy

As of January 3, 2025, Alchemy supports the Ink-Sepolia RPC endpoint. 

<img width="1113" alt="alchemy-ink-sepolia" src="https://github.com/user-attachments/assets/4085a38d-c2f3-47ea-9d90-e60caa47390e" />

