### PR TITLE
fix: Fixed Typo in Interface Name Update ThumbUp.tsx

### DIFF
--- a/src/icons/ThumbUp.tsx
+++ b/src/icons/ThumbUp.tsx
@@ -1,8 +1,8 @@
-interface ThumpUpProps {
+interface ThumbUpProps {
   className?: string;
 }
 
-export const ThumbUpIcon: React.FC<ThumpUpProps> = ({
+export const ThumbUpIcon: React.FC<ThumbUpProps> = ({
   className = "size-6",
 }) => {
   return (


### PR DESCRIPTION
I noticed a typo in the code where the interface name was written as `ThumpUpProps`.
This seems to be a mistake, and I've corrected it to `ThumbUpProps` to ensure consistency and avoid any potential issues. 