### PR TITLE
chore: Improved type safety for SidebarTitleComponentProps

### DIFF
--- a/src/components/SidebarTitleComponent.tsx
+++ b/src/components/SidebarTitleComponent.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 
 interface SidebarTitleComponentProps {
   title: string;
-  type: string;
+  type: "separator" | "otherType";
   route: string;
 }
 


### PR DESCRIPTION
I've updated the `SidebarTitleComponentProps` interface to enforce stricter type safety for the `type` property. Instead of using a generic `string`, it's now limited to `"separator" | "otherType"`, ensuring better type checking and preventing potential errors down the line.