### PR TITLE
Fix broken homepage link in 500 error page

### DIFF
--- a/src/pages/500.mdx
+++ b/src/pages/500.mdx
@@ -2,7 +2,7 @@
 
 ![500 Error Warning.](/img/icons/500-page.svg)
 
-## Something isn't quite right. Let's start again on the [homepage](index).
+## Something isn't quite right. Let's start again on the [homepage](index.mdx).
 
 #### Please help by [submitting an issue](https://github.com/inkonchain/docs/issues/new) for the broken link. ❤️
 


### PR DESCRIPTION
Replaced the incorrect link to the homepage in 500.mdx with a correct reference to index.mdx, ensuring users are redirected properly from the error page.