### PR TITLE
feat: update mystery faucet URL in documentation

### DIFF
--- a/src/content/shared/_badges.mdx
+++ b/src/content/shared/_badges.mdx
@@ -59,7 +59,7 @@ If you want the token to appear in MetaMask, click on the MetaMask button at the
 
 > Awarded for using the Ink faucet.
 
-Get here: [https://mystery-faucet.demo.inkonchain.com/](https://mystery-faucet.demo.inkonchain.com/)
+Get here: [https://mystery-faucet.inkonchain.com/](https://mystery-faucet.inkonchain.com/)
 
 Enter your address, enter the captcha, that's it!
 


### PR DESCRIPTION
Updates the mystery faucet URL from demo subdomain to the main domain following the migration from AWS Amplify to Kubernetes.