### PR TITLE
build: integrate securesdlc workflow

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -6,7 +6,11 @@ on:
       - main
 
 jobs:
+  securesdlc:
+    uses: inkonchain/.github/.github/workflows/securesdlc.yml@main
+
   install_modules:
+    needs: securesdlc
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Integrates the reusable `securesdlc` workflow from the `.github` repository. This workflow runs security checks on the codebase. The `install_modules` job now depends on the successful completion of the `securesdlc` job.