### PR TITLE
Move Cookbook Public API Key to Environment Variable

### DIFF
--- a/src/components/AskCookbook.tsx
+++ b/src/components/AskCookbook.tsx
@@ -2,8 +2,7 @@ import React from "react";
 import BaseAskCookbook from "@cookbookdev/docsbot/react";
 
 /** It's going to be exposed in HTTP requests anyway so it's fine to just hardcode it here */
-const COOKBOOK_PUBLIC_API_KEY =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NzNlNTU5ZjBjOWIwZGRjZTE5OTAwMTIiLCJpYXQiOjE3MzIxMzgzOTksImV4cCI6MjA0NzcxNDM5OX0.L7-tnJwEIoDwxtju0yr5T4Xb9ahjIae8ob4dVbzoADM";
+const COOKBOOK_PUBLIC_API_KEY = process.env.NEXT_PUBLIC_COOKBOOK_API_KEY;
 export const AskCookbook = () => {
   return <BaseAskCookbook apiKey={COOKBOOK_PUBLIC_API_KEY} />;
 };


### PR DESCRIPTION


---


**Description:**  
- Refactored `AskCookbook` component to use `NEXT_PUBLIC_COOKBOOK_API_KEY` from environment variables instead of hardcoding the key.
- Improves configuration flexibility and follows best practices for managing API keys, even if they are public.

---