### PR TITLE
docs: fix link to redstone's docs

### DIFF
--- a/src/pages/tools/oracles.mdx
+++ b/src/pages/tools/oracles.mdx
@@ -54,7 +54,7 @@ See their [guide](https://docs.pyth.network/price-feeds/getting-started) to lear
 
 ## Redstone
 
-Redstone provides both pull and push price feeds for Ink. See [this](https://docs.redstone.finance/docs/get-started/supported-chains/) guide to learn how to use Redstone feeds.
+Redstone provides both pull and push price feeds for Ink. See [this](https://docs.redstone.finance/docs/dapps/redstone-erc7412/#guide) guide to learn how to use Redstone feeds.
 
 | Network     | Feed     | Contract Address                                                                                                                                                          |
 | ----------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
previous one has Page Not Found error, 
<img width="1443" height="832" alt="Zrzut ekranu 2025-07-26 003759" src="https://github.com/user-attachments/assets/7a035d2e-1e7d-4073-bc09-50d2ae8cbfb3" />

