### PR TITLE
docs: fix contract verification

### DIFF
--- a/src/pages/build/tutorials/deploying-a-smart-contract/foundry.mdx
+++ b/src/pages/build/tutorials/deploying-a-smart-contract/foundry.mdx
@@ -161,7 +161,9 @@ If you want to verify your contract on Etherscan:
 ```bash
 forge verify-contract <DEPLOYED_CONTRACT_ADDRESS> src/InkContract.sol:InkContract \
     --chain-id 763373 \
-    --etherscan-api-key $BLOCKSCOUT_API_KEY
+    --verifier blockscout \
+    --verifier-url https://explorer-sepolia.inkonchain.com/api \
+    --verifier-api-key $BLOCKSCOUT_API_KEY
 ```
 
 ## Additional Configuration


### PR DESCRIPTION
This PR updates the “Verifying Your Contract” section in the Foundry deployment guide. Previously, the documentation referenced Etherscan verification using --etherscan-api-key while targeting the Ink Sepolia network, which uses Blockscout instead.

This caused confusion and verification failures when developers attempted to verify contracts on Ink.

Changes:

Replaced all mentions of Etherscan with Blockscout.

Updated the example forge verify-contract command to use the proper Blockscout verifier flags: forge verify-contract <DEPLOYED_CONTRACT_ADDRESS> src/InkContract.sol:InkContract \
    --chain-id 763373 \
    --verifier blockscout \
    --verifier-url https://explorer-sepolia.inkonchain.com/api \
    --verifier-api-key $BLOCKSCOUT_API_KEY

Clarified that the Ink Sepolia network is verified through Blockscout, not Etherscan.

Aligned environment variable names (INKSEPOLIA_RPC_URL instead of RPC_URL) for consistency with Foundry profiles.

Why:

Etherscan and Blockscout use different APIs and are not interchangeable. Ink’s Sepolia network is powered by Blockscout, so verification must target its API endpoint (https://explorer-sepolia.inkonchain.com/api). Without this fix, forge verify-contract fails with an “unsupported chain” error.