### PR TITLE
Add ethfaucet.com faucet

### DIFF
--- a/src/content/shared/faucets-content.mdx
+++ b/src/content/shared/faucets-content.mdx
@@ -21,3 +21,9 @@ Gelato's Faucet uses Cloudflare authentication and drops up to 0.3 Ink Sepolia E
 ## [Tenderly](https://tenderly.co/?mtm_campaign=ext-docs&mtm_kwd=ink)
 
 Tenderly's [Unlimited Faucet](https://docs.tenderly.co/virtual-testnets/unlimited-faucet?mtm_campaign=ext-docs&mtm_kwd=ink) allows you to mint native and ERC20 tokens for development and testing on Virtual TestNets. The unlimited faucet is part of the [Admin RPC](https://docs.tenderly.co/virtual-testnets/admin-rpc?mtm_campaign=ext-docs&mtm_kwd=ink), a collection of cheet-codes allowing full customization of the network.
+
+## [ethfaucet.com](https://ethfaucet.com?utm_source=inkdocs&utm_medium=docs)
+
+[ethfaucet.com](https://ethfaucet.com?utm_source=inkdocs&utm_medium=docs) provides developers with 0.1 Ink Sepolia ETH for free, claimable once every 24 hours. The faucet supports both addresses with transaction history and new addresses via Proof of Humanity verification.
+
+Operated and maintained by [BringID](https://www.bringid.org?utm_source=inkdocs&utm_medium=docs).


### PR DESCRIPTION
**Description**
Adding a new faucet (ethfaucet.com) to the docs.
ethfaucet.com provides developers with 0.1 Ink Sepolia ETH for free, claimable once every 24 hours.

**Additional context**
ethfaucet.com is maintained and powered by BringID. BringID is a proof-of-humanity solution from web accounts helping crypto apps to resist sybil attacks and bot abuse.