### PR TITLE
docs: replace broken link in Oracles doc

### DIFF
--- a/src/pages/tools/oracles.mdx
+++ b/src/pages/tools/oracles.mdx
@@ -4,7 +4,7 @@ import CopyableCode from "@/components/CopyableCode";
 
 ## API3
 
-API3 offers 190+ price feeds for Ink on the [API3 Market](https://market.api3.org/ink). All API3's price feeds are integrated with OEV Network to recapture protocol MEV due to oracle updates. See this [guide](https://docs.api3.org/dapps/) to learn how to integrate API3's data feeds.
+API3 offers 190+ price feeds for Ink on the [API3 Market](https://market.api3.org/). All API3's price feeds are integrated with OEV Network to recapture protocol MEV due to oracle updates. See this [guide](https://docs.api3.org/dapps/) to learn how to integrate API3's data feeds.
 
 | Network     | Contract Address                                                                                                                                                          |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
##Summary: 

Replaces a broken API3 link with the working URL so the Oracles page points to the correct API3 Market.
Files changed: src/pages/tools/oracles.mdx

## What I changed: 
Updated the API3 link to [https://market.api3.org/](vscode-file://vscode-app/c:/Users/Administrator/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (fixed broken/plain-text link).

##Why: 
Prevents a broken navigation/404 and improves docs accuracy for integrators.

How to test: Run the dev site and verify the link on the Oracles page opens the API3 Market.

pnpm dev (or npm run dev) then visit the Oracles page and click the API3 link.

Notes: No functional code changes; safe to merge.