### PR TITLE
Fix RPC_URL mismatch

### DIFF
--- a/src/pages/build/tutorials/deploying-a-smart-contract/foundry.mdx
+++ b/src/pages/build/tutorials/deploying-a-smart-contract/foundry.mdx
@@ -178,7 +178,7 @@ optimizer = true
 optimizer_runs = 200
 
 [rpc_endpoints]
-inksepolia = "${INKSEPOLIA_RPC_URL}"
+inksepolia = "${RPC_URL}"
 ```
 
 ## Next Steps


### PR DESCRIPTION
The tutorial defines the RPC endpoint in `.env` as:
`RPC_URL=https://rpc-gel-sepolia.inkonchain.com/`

and the deployment command uses:
`forge script ... --rpc-url $RPC_URL`

However, the `foundry.toml` example referenced a different variable:
`${INKSEPOLIA_RPC_URL}`

Following the guide step-by-step would therefore create only `RPC_URL`, causing the `foundry.toml` configuration to reference a non-existent environment variable.

This PR makes the tutorial consistent by updating the `foundry.toml` example to use `${RPC_URL}`.

Documentation-only change.