### PR TITLE
fix: avoid stale state usage in useNetwork effect

### DIFF
--- a/src/utils/networks.ts
+++ b/src/utils/networks.ts
@@ -70,7 +70,7 @@ export function useNetwork(network: NetworkType): UseNetworkResponse {
             chainId.toLowerCase() ===
             networkParams[network].chainId.toLowerCase();
           setIsSelected(isCurrentNetwork);
-          setIsAdded(isCurrentNetwork || isAdded); // If we're on the network, it must be added
+          setIsAdded(prev => isCurrentNetwork || prev); // If we're on the network, it must be added
         } catch (error) {
           console.error("Error checking network:", error);
         }
@@ -87,7 +87,7 @@ export function useNetwork(network: NetworkType): UseNetworkResponse {
         window.ethereum.removeListener("chainChanged", checkNetwork);
       };
     }
-  }, [network, isAdded]);
+  }, [network]);
 
   async function addNetwork(): Promise<void> {
     if (!window.ethereum) return;


### PR DESCRIPTION
Use functional state update for isAdded inside useEffect to avoid stale state usage and remove the unnecessary dependency on isAdded. This prevents redundant effect executions while keeping the existing behavior unchanged.