### PR TITLE
chore: add JAW.id to account-abstraction docs

### DIFF
--- a/src/pages/tools/account-abstraction.mdx
+++ b/src/pages/tools/account-abstraction.mdx
@@ -6,8 +6,8 @@ Leverage Alchemy's best in class account abstraction stack, [Account Kit](https:
 
 **Supported Networks**:
 
-* Ink Mainnet
-* Ink Sepolia
+- Ink Mainnet
+- Ink Sepolia
 
 ## Safe
 
@@ -15,8 +15,8 @@ Access Safe’s full suite of tooling including modular smart account infrastruc
 
 **Supported Networks**:
 
-* [Ink Mainnet](https://app.safe.global/new-safe/create?chain=ink)
-* [Ink Sepolia](https://safe.optimism.io/welcome/accounts?chain=ink-sepolia)
+- [Ink Mainnet](https://app.safe.global/new-safe/create?chain=ink)
+- [Ink Sepolia](https://safe.optimism.io/welcome/accounts?chain=ink-sepolia)
 
 ## ZeroDev
 
@@ -24,5 +24,14 @@ ZeroDev is a chain abstracted smart account for building user-friendly Web3 expe
 
 **Supported Networks**:
 
-* Ink Mainnet
-* Ink Sepolia
+- Ink Mainnet
+- Ink Sepolia
+
+## JAW.id
+
+[JAW.id](https://jaw.id) provides a drop-in smart account solution for dApps, integrating via a standard EIP-1193 provider or wagmi connector with no custom bundler or paymaster wiring required. JAW.id offers identity-first infrastructure with passkey authentication, ENS-native identity, programmable session keys, and AI agent delegation.
+
+**Supported Networks**:
+
+- Ink Mainnet
+- Ink Sepolia


### PR DESCRIPTION
Add JAW.id to the Account Abstraction tools page as a supported smart account provider on Ink Mainnet and Ink Sepolia 