### PR TITLE
feat: improve Blockscout verification reference

### DIFF
--- a/src/pages/build/tutorials/deploying-a-smart-contract/foundry.mdx
+++ b/src/pages/build/tutorials/deploying-a-smart-contract/foundry.mdx
@@ -156,7 +156,7 @@ forge script script/Deploy.s.sol:DeployScript --rpc-url $RPC_URL --broadcast --v
 
 ## Verifying Your Contract
 
-If you want to verify your contract on Etherscan:
+If you want to verify your contract on Blockscout:
 
 ```bash
 forge verify-contract <DEPLOYED_CONTRACT_ADDRESS> src/InkContract.sol:InkContract \


### PR DESCRIPTION
The tutorial text said 'verify on Etherscan', although according to the guide, verification is done through Blockscout (the `--etherscan-api-key` flag is a compatible name for the Blockscout API key, but the platform itself is not Etherscan).