### PR TITLE
fix: use dynamic anchor id from network prop in AddNetworkButton

### DIFF
--- a/src/components/AddNetworkButton.tsx
+++ b/src/components/AddNetworkButton.tsx
@@ -28,8 +28,8 @@ export const AddNetworkButton = ({
           <span>{heading}</span>
           {isSelected && <ConnectedPulse className="size-6" />}
           <a
-            href="#mainnet"
-            id="mainnet"
+            href={`#${network}`}
+            id={network}
             className="subheading-anchor"
             aria-label="Permalink for this section"
           ></a>
@@ -86,3 +86,4 @@ const AddNetworkButtonContent = ({
     </Button>
   );
 };
+


### PR DESCRIPTION
## Bug

`AddNetworkButton` hardcodes `id="mainnet"` and `href="#mainnet"` on the section anchor regardless of which `network` prop is passed:

```tsx
<a
  href="#mainnet"    // ❌ always "mainnet"
  id="mainnet"      // ❌ always "mainnet"
  className="subheading-anchor"
  aria-label="Permalink for this section"
></a>
```

When this component is rendered for both mainnet and sepolia on the same page, two elements share `id="mainnet"`, which:
- Produces **invalid HTML** (duplicate `id` attributes)
- Breaks **anchor navigation** — `#mainnet` always jumps to the first matching element, making the second network section unreachable via URL hash
- Fails **WCAG 2.1 accessibility** requirements (each `id` must be unique per page)

## Fix

Derive the `id` and `href` dynamically from the `network` prop:

```tsx
<a
  href={`#${network}`}   // ✅ e.g. "#ink-mainnet" or "#ink-sepolia"
  id={network}           // ✅ unique per network
  className="subheading-anchor"
  aria-label="Permalink for this section"
></a>
```

## Impact

Anywhere this component is rendered for multiple networks on one page, anchor navigation for all networks except the first is silently broken.