### PR TITLE
fix: add rel=noopener noreferrer to external links in Footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,12 +8,12 @@ export const Footer = () => {
           Made with 💜 by the Ink team
         </div>
         <div className="text-sm text-gray-600">
-          <a href="https://inkonchain.com/en-US/privacy" target="_blank">
+          <a href="https://inkonchain.com/en-US/privacy" target="_blank" rel="noopener noreferrer">
             Privacy Notice
           </a>
         </div>
         <div className="text-sm text-gray-600">
-          <a href="https://inkonchain.com/en-US/terms" target="_blank">
+          <a href="https://inkonchain.com/en-US/terms" target="_blank" rel="noopener noreferrer">
             Terms of Service
           </a>
         </div>
@@ -22,3 +22,4 @@ export const Footer = () => {
     </div>
   );
 };
+


### PR DESCRIPTION
## Bug

The `Footer` component renders two external links with `target="_blank"` but no `rel` attribute:

```tsx
<a href="https://inkonchain.com/en-US/privacy" target="_blank">
  Privacy Notice
</a>
<a href="https://inkonchain.com/en-US/terms" target="_blank">
  Terms of Service
</a>
```

Opening a link with `target="_blank"` without `rel="noopener"` gives the opened page access to the opener via `window.opener`. This enables a **reverse tabnapping attack** where a malicious or compromised destination page can redirect the original tab to a phishing page.

Although modern browsers set `rel="noopener"` implicitly for cross-origin navigations since Chrome 88 / Firefox 79, the explicit attribute is still required for:
- Older browser support
- Passing security linters and CSP audits
- ESLint rules (`jsx-a11y/anchor-is-valid`, `react/jsx-no-target-blank`)

## Fix

Add `rel="noopener noreferrer"` to both links:

```tsx
<a href="..." target="_blank" rel="noopener noreferrer">
```

`noreferrer` additionally prevents the `Referer` header from leaking the docs URL to the destination.