### PR TITLE
Update Spark builder program positioning

### DIFF
--- a/cspell/project-words.txt
+++ b/cspell/project-words.txt
@@ -136,6 +136,11 @@ cypherpunk
 predeploy
 DYOR
 subsecond
+Tydro
+Nado
+CLOB
+perps
+waitlists
 microgrants
 Microgrants
 Inkubator

--- a/src/pages/ink-builder-program/overview.mdx
+++ b/src/pages/ink-builder-program/overview.mdx
@@ -2,7 +2,7 @@
 
 The Ink Builder Program supports teams building on Ink with funding, guidance, and recognition across three tracks.
 
-**Spark:** Microgrants for builders shipping tangible progress. Spark backs small, high-signal projects like tools, bots, mini dApps, and experiments that can deliver measurable value on Ink. It is also a path for teams that are promising but not yet at Forge's traction bar to prove impact and level up. Grants range from 500–5,000 USDC, with a lightweight application and fast review.
+**Spark:** Builder grants for live projects creating measurable progress on Ink. Spark backs high-signal tools, bots, mini dApps, integrations, infrastructure, and experiments that are already usable and ready to grow. It is also a path for promising teams to prove traction before pursuing deeper ecosystem support. Grants range from 500-20,000 USDC, with a lightweight application and rolling review.
 
 **Forge:** Our flagship track for teams scaling real products. Forge is built for projects with **live traction** and a clear plan to grow on Ink. Support includes **milestone-based grants up to 200,000 USDC**, hands-on ecosystem support, and exposure through Ink's channels. In select cases, we may back exceptional founders who are strongly aligned with Ink and have a credible path to breakout impact, but traction remains the primary bar.
 

--- a/src/pages/ink-builder-program/spark-program.mdx
+++ b/src/pages/ink-builder-program/spark-program.mdx
@@ -4,48 +4,90 @@
 
 ## What Is Spark?
 
-Spark is Ink's microgrant track for builders shipping small, high-signal work that creates measurable value for the ecosystem.
+Spark is Ink's builder grant track for live projects that can create measurable ecosystem progress.
 
-It's built for tools, bots, mini dApps, public goods, and experimental products that can prove real usage, unlock onchain activity, or make building on Ink easier. Spark is also the right lane for promising teams that are not yet at Forge's traction bar, but can prove impact with a smaller push.
+It is designed as an on-ramp for builders who are already shipping, proving demand, and looking for a focused push to deepen their impact on Ink. Spark remains a broad entry point for tools, bots, mini dApps, infrastructure, public goods, consumer experiments, and other useful products, but funding is selective and alignment-driven.
 
-No pitch decks. Low lift application. Fast decisions.
+The strongest Spark applications show a working product, a clear reason to build on Ink, and a credible path to more users, liquidity, transactions, integrations, or builder leverage.
 
-This is where projects earn their first traction on Ink.
+Spark can also be a stepping stone into Ink's next-stage builder support. Teams that prove meaningful traction through Spark may be better positioned for deeper ecosystem support later.
 
-## Why We Built Spark
+No pitch decks. Low-lift application. Clear expectations.
 
-Healthy ecosystems are built by a lot of small, useful things that compound.
+Low-lift does not mean low-evidence. Spark applicants should be ready to provide verifiable data that can be reviewed and cross-checked. If you claim users, traction, revenue, transactions, volume, TVL, or protocol activity, include the onchain data, contract addresses, dashboards, analytics, or other evidence that supports it.
 
-Spark exists to:
+## What Gets Funded
 
-- Reduce friction for builders who are ready to ship, not just talk
-- Buy velocity for projects that can quickly produce proof (usage, integrations, onchain activity)
-- Seed high-potential teams that need a smaller milestone to qualify for deeper support later
-- Encourage ecosystem primitives and public goods that increase builder throughput
+Spark is open to strong builders across the ecosystem, but we are especially interested in projects that advance Ink's highest-priority growth areas.
 
-Spark is not "fund anything." It is "fund what can ship value and show signal."
+### Tydro Integrations
+
+Tydro is Ink's lending market. We look closely at projects that make Tydro more useful, accessible, or active, including:
+
+- Lending and borrowing strategy tools
+- Looping, yield, vault, or capital efficiency products
+- Risk dashboards, portfolio tools, and user education layers
+- Automation that helps users manage positions responsibly
+- Interfaces or integrations that route meaningful activity to Tydro
+
+### Nado Integrations
+
+Nado is Ink's CLOB perps DEX. We look closely at projects that build on top of Nado, make the protocol more accessible, or create new user experiences around its core infrastructure, including:
+
+- New interfaces, UX abstractions, or account experiences
+- Strategy tools, dashboards, alerts, and analytics
+- AI-assisted or automated protocol interaction workflows
+- Onboarding, education, and portfolio tools that help users understand Nado
+- Integrations that create useful, measurable activity around Nado
+
+### Tydro + Nado Combinations
+
+Projects that connect both protocols in smart, useful ways are especially interesting. This could include products that combine lending, collateral, yield, portfolio management, market data, or risk tooling into one coherent user flow.
+
+### RWA Infrastructure
+
+We are also focused on real-world asset infrastructure native to Ink. Projects that help bring credible RWA activity, tooling, rails, data, compliance-aware workflows, or user-facing RWA products to Ink are strong Spark candidates.
+
+### AI and Agent Infrastructure
+
+We want Ink to be a simple, robust, and verifiable place for agents to transact. Spark is a strong fit for teams building infrastructure that helps AI agents build, trade, send and receive payments, manage wallets, interact with protocols, or make autonomous onchain decisions on Ink.
+
+Strong examples include agent payment rails, trading agents, wallet/action frameworks, verifiable agent workflows, automation tools, and agent-facing integrations with Ink-native protocols.
+
+### Other Strong Outliers
+
+Spark is not limited to the categories above. Games, NFTs, onchain trading tools, payments, consumer apps, public goods, developer tools, community products, and experimental ideas can still be funded if they are live, useful, and make a clear contribution to Ink.
+
+Outlier projects should be especially clear about why Ink is the right home and how the project will create measurable ecosystem value.
 
 ## Who Should Apply
 
 Spark is a strong fit if you are:
 
-- An indie builder or small team shipping a real product or feature
-- A team building something useful for other builders or users on Ink
-- A project that can show a credible plan for measurable impact, even if early
-- A team that may have aimed for Forge but needs to prove traction first
+- An indie builder or small team with a live product, working integration, or usable feature
+- A team building around our core products, RWA infrastructure, AI agents, or another clear priority
+- A project that can show verifiable usage, transactions, volume, integrations, community demand, or other proof that people want what you are building
+- A builder with a specific plan to grow activity, improve UX, increase liquidity, support users, or help other teams build on Ink
+- A promising team that is not yet ready for larger-scale support, but can use Spark to prove stronger traction
 
-Spark is not a fit for deck-first ideas, marketing-only teams, or projects that cannot define what value they create for Ink and how it will be measured.
+Spark is not a fit for deck-first ideas, marketing-only proposals, or projects that cannot explain what value they create for Ink and how that value will be measured.
 
-## What You Can Build
+## What Is Less Likely To Get Funded
 
-Spark supports lightweight projects that increase usage, liquidity, or builder leverage, including:
+Spark is meant to accelerate useful work that already shows proof. It is not designed to fund every early idea or cover ordinary operating costs.
 
-- Developer tools, SDKs, contract tooling, deployment helpers
-- Bots and mini apps that drive repeat onchain actions
-- Onchain UX improvements, onboarding helpers, account abstraction components
-- Analytics dashboards that help users act (not just view), especially if linked to conversion
-- Public goods and open-source primitives other teams can reuse
-- Consumer experiments with clear retention loops and measurable usage
+Projects are less likely to be funded if they are:
+
+- Only an idea, mockup, or early R&D concept with no working product
+- Testnet-only without a clear path to mainnet usage
+- Requesting funds primarily for generic hosting, routine infrastructure, or basic deployment costs
+- Asking for a grant to cover salaries, runway, or general team expenses
+- Seeking capital to test private trading strategies or subsidize user trading
+- Mostly meme, NFT, or marketing activity without clear utility or durable ecosystem value
+- Not meaningfully connected to Ink beyond deploying a contract or adding a chain option
+- Unable to back user, traction, revenue, or activity claims with data reviewers can verify
+
+Prototypes, screenshots, testnet deployments, and design work can help explain what you are building, but they are usually not enough on their own. The best Spark applications point to something live, usable, and ready to grow.
 
 ## How It Works
 
@@ -53,50 +95,56 @@ Spark supports lightweight projects that increase usage, liquidity, or builder l
 
 Builders share a short application with:
 
-- What they're building and why it matters for Ink
-- Proof of build (demo, repo, screenshots, Loom, contracts, etc.)
-- What they want to ship or improve with a $500–$5K microgrant
-- Any traction signals (even small) and distribution plan (if relevant)
+- What they are building and why it matters for Ink
+- Proof that the product works, such as a live app, repo, demo, mainnet contract, Loom, dashboard, or other usable artifact
+- The grant amount requested and how the funds would help the project scale or deepen impact
+- Verifiable traction signals, such as users, transactions, volume, TVL, integrations, retention, waitlists, community demand, revenue, or partner interest, with onchain data or supporting evidence where applicable
+- Any relevant Tydro, Nado, RWA, AI/agent, or other Ink ecosystem alignment
 
-### 2) Review (Scorecard-Based)
+### 2) Review
 
-We evaluate every submission on five criteria:
+We evaluate every submission on six criteria:
 
-- **Proof of Build**
-    
-    Has real work already started, code/UI/prototype/demo, visible effort.
-    
-- **Ecosystem Usefulness**
-    
-    Does it make Ink more usable, more visible, or more fun, and does it help users or other builders.
-    
-- **Feasibility for Microgrant**
-    
-    Can $500–$5K meaningfully move it forward, with a clear and realistic scope.
-    
+- **Ink Ecosystem Alignment**
+
+  Does the project clearly support Ink's users, builders, liquidity, protocol activity, or strategic growth areas?
+
+- **Proof of Live Utility**
+
+  Is there a working product, integration, deployment, or user-facing feature that reviewers can actually inspect?
+
+- **Measurable Traction**
+
+  Can the team show usage, transactions, volume, TVL, integrations, retained users, developer adoption, revenue, or another meaningful signal with data reviewers can verify?
+
+- **Priority Fit**
+
+  Does the project build around Tydro, Nado, RWA infrastructure, AI/agent infrastructure, or another high-value Ink opportunity?
+
+- **Responsible Use of Funds**
+
+  Would the grant help the team ship, grow, integrate, or scale something users already want, rather than cover ordinary costs or early experimentation?
+
 - **Builder Credibility**
-    
-    Can the builder ship, communicate clearly, and respond reliably.
-    
-- **Creative + Value Spark**
-    
-    Is it novel, memeable, surprising, or culturally sticky, while still creating real value.
+
+  Can the builder ship, communicate clearly, respond reliably, and own the next phase of execution?
 
 ### 3) Decision + Grant
 
 Outcomes:
 
 - **Approved** (grant size confirmed)
-- **Revise & resubmit** (scope or proof needs tightening)
-- **Not a fit** (doesn't match Spark goals)
+- **Revise & resubmit** (scope, proof, or alignment needs tightening)
+- **Not a fit** (does not match Spark's current funding priorities)
 
 ## What You Receive
 
-### Microgrants
+### Spark Grants
 
-- **500–5,000 USDC** per project
+- **500-20,000 USDC** per project
 - Non-dilutive, simple terms
-- Typically paid after approval and confirmation of a working build/demo (timing depends on program operations and compliance)
+- Grant size depends on traction, maturity, scope, and expected ecosystem impact
+- Typically paid after approval and confirmation of a working build or live deployment, subject to program operations and compliance
 
 ### Visibility and Ecosystem Support
 
@@ -104,23 +152,11 @@ Standout Spark projects may receive:
 
 - Social amplification and ecosystem highlights
 - Introductions to relevant ecosystem teams and partners
-- A clear path to "level up" into deeper support when traction is proven
-
-## Spark Success Looks Like
-
-Within the next phase, the project delivers:
-
-- A live deployment or usable feature on Ink
-- A measurable impact signal, such as:
-    - real users or repeat usage
-    - meaningful onchain activity (transactions, volume)
-    - adoption by other builders (integrations, reuse, tooling usage)
-    - clear improvements to conversion or usability
-
-If a project cannot explain the value it creates for Ink and how that value will be measured, it is not a fit.
+- Product, integration, or go-to-market feedback
+- A clearer path to level up into deeper support when traction is proven
 
 ## How To Join Spark
 
-- Submit your project → [Spark Application Form](https://forms.inkonchain.com/spark-builder-program)
-- Get reviewed → The team reviews applications in batches and follows up with results
-- Ship and prove → Spark is designed to reward builders who deliver measurable value, not just announcements
+- Submit your project -> [Spark Application Form](https://forms.inkonchain.com/spark-builder-program)
+- Get reviewed -> The team reviews applications in rolling batches and follows up with decisions or questions
+- Ship and prove -> Spark rewards builders who deliver measurable value, not just announcements


### PR DESCRIPTION
## Summary
- Reframes Spark from microgrants to builder grants for live, measurable Ink-aligned projects.
- Adds priority areas for Tydro, Nado, RWA, and AI/agent infrastructure while preserving room for strong outliers.
- Updates the Builder Program overview and spellcheck dictionary for new protocol/program terms.

## Test plan
- pnpm exec remark src/pages/ink-builder-program/spark-program.mdx src/pages/ink-builder-program/overview.mdx --quiet --frail
- pnpm exec cspell lint src/pages/ink-builder-program/spark-program.mdx src/pages/ink-builder-program/overview.mdx

Made with [Cursor](https://cursor.com)