### PR TITLE
docs: fix invalid JSX attribute in ink-kit example

### DIFF
--- a/src/pages/build/ink-kit.mdx
+++ b/src/pages/build/ink-kit.mdx
@@ -80,7 +80,7 @@ By default, Ink Kit provides a couple of themes already in the stylesheet:
 To specify which theme to use, add the `ink:THEME_ID` to your document root:
 
 ```tsx
-<html class="ink:dark-theme">
+<html className="ink:dark-theme">
   ...
 ```
 


### PR DESCRIPTION
`class` > `className`

In JSX/TSX, `class` is a syntax error - the correct attribute is `className`. Without this fix, the example breaks when copied into a React/Next.js project.