### PR TITLE
fix: remove debug console.log from useNetwork hook

### DIFF
--- a/src/utils/networks.ts
+++ b/src/utils/networks.ts
@@ -56,8 +56,6 @@ export function useNetwork(network: NetworkType): UseNetworkResponse {
   const [isAdded, setIsAdded] = useState<boolean>(false);
   const [isSelected, setIsSelected] = useState<boolean>(false);
 
-  console.log(`${network} is added: ${isAdded}`);
-
   // Check if network is added and selected on mount and when network changes
   useEffect(() => {
     const checkNetwork = async () => {


### PR DESCRIPTION
## Summary
- Removes a leftover debug `console.log` from `useNetwork` in `src/utils/networks.ts` that ran on every render of the Connect Wallet page.

## Why
The log (`${network} is added: ${isAdded}`) added unnecessary console noise without providing user-facing value. Error handling via `console.error` is unchanged.

## Test plan
- [x] Open `/general/connect-wallet`
- [x] Confirm Mainnet and Sepolia network sections still render
- [x] Confirm debug `console.log` is removed from `useNetwork`