### PR TITLE
Fix broken Brid.gg bridge links by removing incorrect path suffixes

### DIFF
--- a/src/pages/tools/bridges.mdx
+++ b/src/pages/tools/bridges.mdx
@@ -26,8 +26,8 @@ Brid.gg enables you to bridge assets from L1 to L2 across the Superchain.
 
 **Supported Networks**
 
-- [Ink Mainnet](https://brid.gg/ink)
-- [Ink Sepolia](https://testnet.brid.gg/ink-sepolia)
+- [Ink Mainnet](https://brid.gg)
+- [Ink Sepolia](https://testnet.brid.gg)
 
 ## Bungee
 


### PR DESCRIPTION
## Problem

The documentation linked to `brid.gg/ink` and `testnet.brid.gg/ink-sepolia`, but these URLs are invalid and result in inaccessible bridge pages.

## Solution

Updated both links to the correct `Brid.gg` endpoints without the unsupported path suffixes, ensuring users are directed to the working bridge pages.

<img width="1137" height="717" alt="image" src="https://github.com/user-attachments/assets/28c2aa80-b9fb-4124-a58e-5068fcbe42da" />

