### PR TITLE
pre-select Ink on Brid.gg mainnet bridge link

### DIFF
--- a/src/pages/tools/bridges.mdx
+++ b/src/pages/tools/bridges.mdx
@@ -26,7 +26,7 @@ Brid.gg enables you to bridge assets from L1 to L2 across the Superchain.
 
 **Supported Networks**
 
-- [Ink Mainnet](https://brid.gg)
+- [Ink Mainnet](https://www.brid.gg/?toChain=57073)
 - [Ink Sepolia](https://testnet.brid.gg)
 
 ## Bungee


### PR DESCRIPTION
Brid.gg migrated to a LI.FI widget that deep-links via query params. Use ?toChain=57073 (Ink's chain ID) so the Mainnet link lands with Ink pre-selected as the destination. Sepolia left as-is since the widget build doesn't include Ink Sepolia (763373).