### PR TITLE
docs: add Garden to bridges list

### DIFF
--- a/src/pages/tools/bridges.mdx
+++ b/src/pages/tools/bridges.mdx
@@ -37,6 +37,14 @@ Bungee aggregates multiple bridges and DEXs to find the most cost-effective rout
 
 - [Ink Mainnet](https://bungee.exchange)
 
+## Garden
+
+Garden enables native Bitcoin bridging to and from Ink using atomic swaps, with no wrapped assets or custodial intermediaries.
+
+**Supported Networks**
+
+- [Ink Mainnet](https://app.garden.finance)
+
 ## Gelato
 
 Gelato's user friendly bridge UI allows users to bridge to Ink quickly and easily.


### PR DESCRIPTION
Adds Garden to the bridges directory, inserted alphabetically between Bungee and Gelato.

Every bridge currently listed moves ETH and ERC-20s between L1 and L2. None of them support native Bitcoin. Garden fills that gap for Ink: users bridge BTC directly to and from Ink via atomic swaps, without wrapped assets or a custodial intermediary holding funds mid-transit.

Ink Mainnet is live and supported today.