### PR TITLE
docs: align builder program docs with Forge deprecation

### DIFF
--- a/src/pages/ink-builder-program/_meta.json
+++ b/src/pages/ink-builder-program/_meta.json
@@ -6,7 +6,7 @@
     "newWindow": true
   },
   "spark-program": "Spark Program",
-  "forge-program": "Forge Program",
-  "echo-program": "Echo Program",
+  "forge-program": "Forge Program (archived)",
+  "echo-program": "Echo Program (closed)",
   "office-hours": "Office Hours"
 }

--- a/src/pages/ink-builder-program/echo-program.mdx
+++ b/src/pages/ink-builder-program/echo-program.mdx
@@ -50,7 +50,7 @@ Approved teams received:
 
 Echo formally recognized early builders.
 
-Ink's other builder tracks support ongoing development:
+Ink's active builder programs support ongoing development:
 
 - **Spark** supports builders who are already shipping and pushing a live product toward meaningful usage.
-- **Forge** backs teams with traction, strong product fundamentals, and a serious ambition to scale on Ink.
+- **Inkworks** is Ink's flagship builder program and supersedes Forge. [Learn more about Inkworks](https://ink.works).

--- a/src/pages/ink-builder-program/forge-program.mdx
+++ b/src/pages/ink-builder-program/forge-program.mdx
@@ -3,7 +3,7 @@ import { Callout } from "nextra/components";
 # Forge Program
 
 <Callout type="warning" emoji="⚠️">
-  The Forge Program is no longer accepting applications. Forge has been superseded by [Inkworks](https://ink.works).
+  The Forge Program is no longer accepting applications and has been superseded by [Inkworks](https://ink.works). The information below is retained for historical reference.
 </Callout>
 
 The future isn't written. It's waiting to be inked.

--- a/src/pages/ink-builder-program/overview.mdx
+++ b/src/pages/ink-builder-program/overview.mdx
@@ -1,9 +1,11 @@
 # Ink Builder Program
 
-The Ink Builder Program supports teams building on Ink with funding, guidance, and recognition across three tracks.
+The Ink Builder Program currently supports teams through Spark and Inkworks. Forge and Echo are retained in these docs as historical programs.
 
 **Spark:** Builder grants for live projects creating measurable progress on Ink. Spark backs high-signal tools, bots, mini dApps, integrations, infrastructure, and experiments that are already usable and ready to grow. It is also a path for promising teams to prove traction before pursuing deeper ecosystem support. Grants range from 500-20,000 USDC, with a lightweight application and rolling review.
 
-**Forge:** Our flagship track for teams scaling real products. Forge is built for projects with **live traction** and a clear plan to grow on Ink. Support includes **milestone-based grants up to 200,000 USDC**, hands-on ecosystem support, and exposure through Ink's channels. In select cases, we may back exceptional founders who are strongly aligned with Ink and have a credible path to breakout impact, but traction remains the primary bar.
+**Inkworks:** Ink's flagship builder program, which supersedes Forge. [Learn more and apply](https://ink.works).
 
-**Echo:** A one-time retroactive track to recognize early projects that shipped on Ink **before November 1, 2025**. Echo rewards verifiable, shipped contributions with a one-time grant and public recognition.
+**Forge (archived):** Forge previously supported teams scaling products with live traction. The program is no longer accepting applications and has been superseded by Inkworks.
+
+**Echo (closed):** Echo was a one-time retroactive track that recognized early projects that shipped on Ink **before November 1, 2025** with grants and public recognition. Submissions closed on March 4, 2026.


### PR DESCRIPTION
## Summary

- Present Spark and Inkworks as the active Ink Builder Programs
- Mark Forge as archived and Echo as closed in the navigation and overview
- Replace the stale active Forge reference on the Echo page with Inkworks
- Clarify that the remaining Forge documentation is retained for historical reference

## Context

Forge was superseded by Inkworks in #610, but the Builder Program overview and Echo page still described Forge as an active flagship program.

This update aligns the related documentation while preserving the original Forge page as a historical reference.

## Validation

- [x] Validated `src/pages/ink-builder-program/_meta.json`
- [x] Checked the diff with `git diff --check`
- [x] Confirmed stale active Forge references were removed outside the archived Forge page