### PR TITLE
fix: correct RPC env var name in Foundry tutorial

### DIFF
--- a/src/pages/build/tutorials/deploying-a-smart-contract/foundry.mdx
+++ b/src/pages/build/tutorials/deploying-a-smart-contract/foundry.mdx
@@ -178,7 +178,7 @@ optimizer = true
 optimizer_runs = 200
 
 [rpc_endpoints]
-inksepolia = "${INKSEPOLIA_RPC_URL}"
+inksepolia = "${RPC_URL}"
 ```
 
 ## Next Steps


### PR DESCRIPTION
## Problem

In the Foundry deployment tutorial (`src/pages/build/tutorials/deploying-a-smart-contract/foundry.mdx`), the `foundry.toml` configuration references an environment variable `${INKSEPOLIA_RPC_URL}` for the Ink Sepolia RPC endpoint. However, the accompanying `.env` file example in the same tutorial defines `RPC_URL`, not `INKSEPOLIA_RPC_URL`.

This mismatch causes the RPC endpoint to resolve to an empty string, breaking deployment to Ink Sepolia for users following the tutorial.

## Fix

Changed the `foundry.toml` rpc_endpoints configuration from `${INKSEPOLIA_RPC_URL}` to `${RPC_URL}` to match the variable name used in the `.env` example.

## Why this is safe

- Single-line change: only the environment variable name in the Foundry config.
- The new value `${RPC_URL}` exactly matches the variable defined in the tutorial's own `.env` example (line 122).
- No logic changes; only fixes a documentation inconsistency that would cause runtime failures.