### PR TITLE
Add Envio to Indexers

### DIFF
--- a/src/pages/tools/indexers.mdx
+++ b/src/pages/tools/indexers.mdx
@@ -1,5 +1,13 @@
 # Indexers
 
+## [Envio](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=ink&utm_medium=partner-docs)
+
+Envio is a high-performance indexing framework that turns Ink smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. On Ink, HyperIndex is powered by HyperSync for historical syncs up to 2000x faster than traditional RPC. You can auto-generate an indexer from any verified contract with `pnpx envio init`, write handlers in TypeScript, JavaScript, or ReScript, and deploy to Envio Cloud or self-host.
+
+**Supported Networks**
+
+* Ink Mainnet
+
 ## [Goldsky](https://docs.goldsky.com/chains/ink)
 
 Goldsky is a high-performance data indexing provider for Ink that makes it easy to extract, transform, and load on-chain data to power both application and analytics use cases. Goldsky offers two primary approaches to indexing and accessing blockchain data: Subgraphs (high-performance subgraphs) and Mirror (real-time data replication pipelines).

--- a/src/pages/tools/indexers.mdx
+++ b/src/pages/tools/indexers.mdx
@@ -2,7 +2,7 @@
 
 ## [Envio](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=ink&utm_medium=partner-docs)
 
-Envio is a high-performance indexing framework that turns Ink smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. On Ink, HyperIndex is powered by HyperSync for historical syncs up to 2000x faster than traditional RPC. You can auto-generate an indexer from any verified contract with `pnpx envio init`, write handlers in TypeScript, JavaScript, or ReScript, and deploy to Envio Cloud or self-host. See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=ink&utm_medium=partner-docs).
+Envio is the data layer for blockchain apps. It gives Ink developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. On Ink, HyperIndex is powered by HyperSync for historical syncs up to 2000x faster than traditional RPC. You can auto-generate an indexer from any verified contract with `pnpx envio init`, write handlers in TypeScript, JavaScript, or ReScript, and deploy to Envio Cloud or self-host. See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=ink&utm_medium=partner-docs).
 
 **Supported Networks**
 

--- a/src/pages/tools/indexers.mdx
+++ b/src/pages/tools/indexers.mdx
@@ -1,8 +1,8 @@
 # Indexers
 
-## [Envio](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=ink&utm_medium=partner-docs)
+## [Envio](https://envio.dev/?utm_source=ink&utm_medium=partner-docs)
 
-Envio is the data layer for blockchain apps. It gives Ink developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. On Ink, HyperIndex is powered by HyperSync for historical syncs up to 2000x faster than traditional RPC. You can auto-generate an indexer from any verified contract with `pnpx envio init`, write handlers in TypeScript, JavaScript, or ReScript, and deploy to Envio Cloud or self-host. See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=ink&utm_medium=partner-docs).
+Envio is the data layer for blockchain apps. It gives Ink developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. On Ink, HyperIndex is powered by HyperSync for historical syncs up to 2000x faster than traditional RPC. You can auto-generate an indexer from any verified contract with `pnpx envio init`, write handlers in TypeScript, JavaScript, or ReScript, and deploy to Envio Cloud or self-host.
 
 **Supported Networks**
 

--- a/src/pages/tools/indexers.mdx
+++ b/src/pages/tools/indexers.mdx
@@ -2,7 +2,7 @@
 
 ## [Envio](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=ink&utm_medium=partner-docs)
 
-Envio is a high-performance indexing framework that turns Ink smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. On Ink, HyperIndex is powered by HyperSync for historical syncs up to 2000x faster than traditional RPC. You can auto-generate an indexer from any verified contract with `pnpx envio init`, write handlers in TypeScript, JavaScript, or ReScript, and deploy to Envio Cloud or self-host.
+Envio is a high-performance indexing framework that turns Ink smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. On Ink, HyperIndex is powered by HyperSync for historical syncs up to 2000x faster than traditional RPC. You can auto-generate an indexer from any verified contract with `pnpx envio init`, write handlers in TypeScript, JavaScript, or ReScript, and deploy to Envio Cloud or self-host. See Envio's [performance benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=ink&utm_medium=partner-docs).
 
 **Supported Networks**
 

--- a/src/pages/tools/indexers.mdx
+++ b/src/pages/tools/indexers.mdx
@@ -16,3 +16,11 @@ Alchemy provides high performance data indexing and subgraphs for Ink alongside 
 **Supported Networks**
 
 * Ink Mainnet
+
+## [Envio](https://envio.dev/?utm_source=ink&utm_medium=partner-docs)
+
+Envio is the data layer for blockchain apps. It gives Ink developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud. On Ink, HyperIndex is powered by HyperSync for historical syncs up to 2000x faster than traditional RPC. You can auto-generate an indexer from any verified contract with `pnpx envio init`, write handlers in TypeScript, JavaScript, or ReScript, and deploy to Envio Cloud or self-host.
+
+**Supported Networks**
+
+* Ink Mainnet


### PR DESCRIPTION
Adds Envio to the Indexers page for Ink, matching the existing entry format.

Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API, with managed hosting on Envio Cloud. On Ink it is powered by HyperSync for fast historical syncs.

- Website: https://envio.dev/
- Docs: https://docs.envio.dev/
- HyperIndex overview: https://docs.envio.dev/docs/HyperIndex/overview