### PR TITLE
docs: link OpenChainBench public Ink RPC latency benchmark

### DIFF
--- a/src/pages/tools/rpc.mdx
+++ b/src/pages/tools/rpc.mdx
@@ -136,3 +136,9 @@ dRPC provides globally distributed nodes for public and premium Ink RPC endpoint
 - HTTPS: <CopyableCode code="https://ink-sepolia.drpc.org" />
 - Websocket: <CopyableCode code="wss://ink-sepolia.drpc.org" />
 
+---
+
+## Public latency benchmarks
+
+To compare the public endpoints above from your region, see [OpenChainBench / ink-rpc](https://openchainbench.com/benchmarks/ink-rpc), an open-source ([ChainBench/openchainbench](https://github.com/ChainBench/openchainbench)) probe that calls `eth_getBlockByNumber` on each keyless provider every 60 seconds from Paris, Virginia, and Singapore, and publishes p50 / p95 latency and availability.
+


### PR DESCRIPTION
## Summary

Adds a short subsection at the end of `src/pages/tools/rpc.mdx` (under the existing "Public Endpoints" section) linking to a public, multi-region latency benchmark of Ink's keyless RPC endpoints.

The goal is to give integrators an independent signal when choosing between the four public providers already documented on this page (Gelato, Tenderly, QuickNode, dRPC).

## What it links to

[OpenChainBench / ink-rpc](https://openchainbench.com/benchmarks/ink-rpc) — an open-source ([ChainBench/openchainbench](https://github.com/ChainBench/openchainbench)) probe run from Paris (eu-west), Virginia (us-east) and Singapore (ap-southeast). It:

- Calls `eth_getBlockByNumber` on each keyless provider every 60 seconds from all 3 regions.
- Publishes p50 / p95 wall-clock request latency and availability.
- Rolls up 24 h / 7 d / 30 d views with methodology and raw JSON.

No API keys, no signup, no paywall.

## Why here

The "Public Endpoints" section lists the four keyless providers side by side with only marketing blurbs. A single-line reference to a neutral, open benchmark lets integrators compare them from their own region before committing.

## Notes

- Diff is 6 lines, 1 file.
- The benchmark covers exactly the four keyless providers already listed here (Gelato `rpc-gel`, Tenderly `rpc-ten`, QuickNode `rpc-qnd`, dRPC `ink.drpc.org`).
- I am not affiliated with any of the providers on the benchmark; happy to reword if the phrasing reads as promotional.