### PR TITLE
fix(docs): use Blockscout verifier flags in Foundry verification example

### DIFF
--- a/src/pages/build/tutorials/deploying-a-smart-contract/foundry.mdx
+++ b/src/pages/build/tutorials/deploying-a-smart-contract/foundry.mdx
@@ -156,12 +156,14 @@ forge script script/Deploy.s.sol:DeployScript --rpc-url $RPC_URL --broadcast --v
 
 ## Verifying Your Contract
 
-If you want to verify your contract on Etherscan:
+If you want to verify your contract on Blockscout:
 
 ```bash
 forge verify-contract <DEPLOYED_CONTRACT_ADDRESS> src/InkContract.sol:InkContract \
     --chain-id 763373 \
-    --etherscan-api-key $BLOCKSCOUT_API_KEY
+    --verifier blockscout \
+    --verifier-url https://explorer-sepolia.inkonchain.com/api \
+    --verifier-api-key $BLOCKSCOUT_API_KEY
 ```
 
 ## Additional Configuration


### PR DESCRIPTION
## Summary

The Foundry deployment guide uses `--etherscan-api-key` in the contract verification example, but Ink Sepolia verifies through **Blockscout**, not Etherscan. As reported in #609, this makes `forge verify-contract` fail with an "unsupported chain" error.

## Change

**Before:**

forge verify-contract <DEPLOYED_CONTRACT_ADDRESS> src/InkContract.sol:InkContract \
--chain-id 763373 \
--etherscan-api-key $BLOCKSCOUT_API_KEY

**After:**
orge verify-contract <DEPLOYED_CONTRACT_ADDRESS> src/InkContract.sol:InkContract \
--chain-id 763373 \
--verifier blockscout \
--verifier-url https://explorer-sepolia.inkonchain.com/api \
--verifier-api-key $BLOCKSCOUT_API_KEY


Also updates the section wording from "on Etherscan" to "on Blockscout" for consistency.

## Notes

Minimal diff: 2 lines removed, 4 added, no other content touched. Commit is GPG-signed.

Closes #609
