### PR TITLE
ci: check formatting instead of rewriting files

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -67,7 +67,7 @@ jobs:
       - uses: ./.github/actions/base-setup
         name: Base Setup
       - name: Run formatting
-        run: pnpm run format:js
+        run: pnpm run format:js:check
 
   # spell-check:
   #   needs: install_modules


### PR DESCRIPTION
Update the formatting CI job to validate formatting instead of rewriting files.

- Replace `pnpm run format:js` with `pnpm run format:js:chec`. 
- `format:js` uses Prettier `--write`, which modifies files instead of validating them.
- `format:js:check` uses Prettier `--check` and fails when formatting differs. 
- `format:js:check` is already defined in `package.json` and is used by the main `lint` script.

This ensures the CI formatting job acts as a validation gate instead of silently rewriting files inside the runner.