### PR TITLE
docs: add Uniblock to the RPC provider directory

### DIFF
--- a/cspell/project-words.txt
+++ b/cspell/project-words.txt
@@ -152,3 +152,4 @@ Hypernative
 Hypernative's
 predeterministic
 sfrx
+Uniblock

--- a/src/pages/tools/rpc.mdx
+++ b/src/pages/tools/rpc.mdx
@@ -64,6 +64,14 @@ dRPC provides enterprise-level RPC infrastructure with globally distributed node
   [dRPC](https://drpc.org/chainlist/ink) works seamlessly with Ink and all Superchain networks.
 </Callout>
 
+## [Uniblock](https://uniblock.dev/chains/ink/?utm_source=ink-docs&utm_medium=ecosystem-docs&utm_campaign=ecosystem&utm_content=intro)
+
+Uniblock provides a unified JSON-RPC endpoint that routes requests across 55+ upstream providers with automatic failover.
+
+**Supported Networks**
+
+- Ink Mainnet
+- Ink Sepolia
 
 <br />
 <br />


### PR DESCRIPTION
Adds Uniblock to the RPC provider directory.

Uniblock provides a unified JSON-RPC endpoint that routes requests across 55+ upstream providers with automatic failover. Ink Mainnet and Ink Sepolia are both supported.

**Scope:** one section in `src/pages/tools/rpc.mdx`, plus one word appended to `cspell/project-words.txt`.

- Matches the existing `## [Name](site)` heading, one-sentence blurb, and **Supported Networks** format
- No `<Callout>`, consistent with the Alchemy and Gelato entries
- Appended after dRPC, preserving the section's existing append order
- Nothing added to **Public Endpoints**, since that section lists keyless endpoints and Uniblock requires an API key header
- `cspell/project-words.txt` gets a single appended line, per the README instruction for new project terms. The file is not re-sorted, to avoid conflicting with other open PRs

Disclosure: I work at Uniblock. Happy to adjust the wording, the link, or the placement to fit your guidelines.