### PR TITLE
Remove leftover placeholder content from 500 page

### DIFF
--- a/src/pages/500.mdx
+++ b/src/pages/500.mdx
@@ -5,7 +5,3 @@
 ## Something isn't quite right. Let's start again on the [homepage](index).
 
 #### Please help by [submitting an issue](https://github.com/inkonchain/docs/issues/new) for the broken link. ❤️
-
-# CHANGE
-
-\n


### PR DESCRIPTION
Remove the leftover `# CHANGE` heading and literal `\n` from the 500 error page. These are unintended placeholder content and should not be displayed to users.