### PR TITLE
docs: remove orphaned stub page general/faucet.mdx

### DIFF
--- a/src/pages/general/faucet.mdx
+++ b/src/pages/general/faucet.mdx
@@ -1,3 +1,0 @@
-# Faucets
-
-## TODO


### PR DESCRIPTION
This page contains only a "## TODO" placeholder heading and is not linked from anywhere in the app.

- src/pages/general/_meta.json already redirects the "Faucet" nav item to /tools/faucets via href.
- The actual faucet content is served by src/pages/tools/faucets.mdx using the FaucetsContentWrapper component.

Because the file still lives under src/pages, Next.js/Nextra serves it directly at /general/faucet, so anyone who reaches that URL sees a blank stub page instead of a 404 or the real content. Removing it cleans this up with no change to the working faucet page or navigation.