### PR TITLE
docs: update Hardhat snippets to Ethers v6 and streamline onchain clients example

### DIFF
--- a/src/pages/build/onchain-clients.mdx
+++ b/src/pages/build/onchain-clients.mdx
@@ -30,14 +30,14 @@ To connect to Ink by instantiating a new `ethers.js` `JsonRpcProvider` object wi
 3. **Using the Provider**: You can now use the `provider` to interact with Ink's testnet. For example, you can fetch the current block number or interact with smart contracts deployed on the testnet.
 
    ```javascript
-   // previous code
+   import { ethers } from 'ethers';
+
+   const rpcUrl = 'https://rpc-gel-sepolia.inkonchain.com';
+   const provider = new ethers.JsonRpcProvider(rpcUrl, 763373);
+
    const blockNumber = await provider.getBlockNumber();
-   console.log(blockNumber);
+   console.log('Current block number:', blockNumber);
    ```
-
-### Example: Fetching the Current Block Number
-
-The following code snippet demonstrates how to fetch and print the current block number from Ink's testnet:
 
 ## Viem - Instructions for Connecting to Ink
 

--- a/src/pages/build/tutorials/deploying-a-smart-contract/hardhat.mdx
+++ b/src/pages/build/tutorials/deploying-a-smart-contract/hardhat.mdx
@@ -122,7 +122,7 @@ describe("InkContract", function () {
   it("Should return the correct greeting", async function () {
     const InkContract = await ethers.getContractFactory("InkContract");
     const contract = await InkContract.deploy();
-    await contract.deployed();
+    await contract.waitForDeployment();
 
     expect(await contract.greeting()).to.equal("Hello, Ink!");
   });
@@ -144,9 +144,9 @@ async function main() {
   const InkContract = await ethers.getContractFactory("InkContract");
   const contract = await InkContract.deploy();
 
-  await contract.deployed();
+  await contract.waitForDeployment();
 
-  console.log("InkContract deployed to:", contract.address);
+  console.log("InkContract deployed to:", await contract.getAddress());
 }
 
 main()


### PR DESCRIPTION
Updated Hardhat test and deploy scripts in deploying-a-smart-contract/hardhat.mdx from legacy Ethers v5 syntax (contract.deployed() and contract.address) to Ethers v6 (waitForDeployment() and getAddress()) matching hardhat-toolbox. In onchain-clients.mdx, cleaned up the Ethers example and removed the empty example section header.