### PR TITLE
Remove unsupported OKX Explorer entry

### DIFF
--- a/src/pages/tools/block-explorers.mdx
+++ b/src/pages/tools/block-explorers.mdx
@@ -9,14 +9,6 @@ Blockscout is a universal block explorer providing detailed chain information an
 * [Ink Mainnet](https://explorer.inkonchain.com/)
 * [Ink Sepolia](https://explorer-sepolia.inkonchain.com/)
 
-## OKX Explorer
-
-OKX Explorer offers streamlined onchain data access, advanced tools, and unified bridge insights across integrated chains for developers.
-
-**Supported Networks**
-
-* [Ink Mainnet](https://web3.okx.com/explorer/inkchain)
-
 ## Routescan
 
 The world’s first multichain explorer provides seamless access to +100 chains, offering a 48h Explorer setup with Full History APIs, Enhanced Charts, and powerful developer tools.


### PR DESCRIPTION
## Summary

Atm, the OKX link leads to `404`.

- Verified the current OKX Explorer and could not find Ink among the supported networks.
- Removed the outdated OKX Explorer entry from the documentation.