### PR TITLE
Remove outdated Routescan explorer entry

### DIFF
--- a/src/pages/tools/block-explorers.mdx
+++ b/src/pages/tools/block-explorers.mdx
@@ -17,15 +17,6 @@ OKX Explorer offers streamlined onchain data access, advanced tools, and unified
 
 * [Ink Mainnet](https://web3.okx.com/explorer/inkchain)
 
-## Routescan
-
-The world’s first multichain explorer provides seamless access to +100 chains, offering a 48h Explorer setup with Full History APIs, Enhanced Charts, and powerful developer tools.
-
-**Supported Networks**
-
-* [Ink Mainnet](https://57073.routescan.io/)
-* [Ink Sepolia](https://sepolia.inkonscan.xyz/)
-
 ## Tenderly
 
 Tenderly's [Developer Explorer](https://docs.tenderly.co/developer-explorer?mtm_campaign=ext-docs&mtm_kwd=ink) is a multi-chain explorer offering view of your smart contract transactions, events, and logs.


### PR DESCRIPTION
## Summary

- Checked Routescan's official list of [supported chains](https://routescan.io/docs/getting-started/supported-chains):
<img width="762" height="648" alt="image" src="https://github.com/user-attachments/assets/afde0b34-b988-4349-808e-1b0c710bd90a" />

- `Ink` is no longer listed among the `supported networks`.
- Removed the outdated `Routescan` explorer entry from the documentation.