### PR TITLE
fix(spellcheck): add missing project words so `pnpm run lint` passes

### DIFF
--- a/cspell/project-words.txt
+++ b/cspell/project-words.txt
@@ -153,3 +153,7 @@ Hypernative's
 predeterministic
 sfrx
 Uniblock
+roadmaps
+Inkworks
+tokenomics
+Matrixed


### PR DESCRIPTION
### Problem

`pnpm run lint` fails on `main`.

The `lint` script chains four gates:

```
lint = lint:js && lint:mdx && format:js:check && spellcheck:lint
```

The first three pass. `spellcheck:lint` fails with 5 issues across 4 files:

```
src/pages/ink-builder-program/echo-program.mdx:20:27    - Unknown word (roadmaps)
src/pages/ink-builder-program/forge-program.mdx:6:88    - Unknown word (Inkworks)
src/pages/ink-builder-program/forge-program.mdx:150:119 - Unknown word (Inkworks)
src/pages/ink-builder-program/office-hours.mdx:49:17    - Unknown word (tokenomics)
src/pages/tools/rpc.mdx:78:83                           - Unknown word (Matrixed)

CSpell: Files checked: 53, Issues found: 5 in 4 files.
```

Because `lint` is a `&&` chain and `spellcheck:lint` is last, a contributor who runs the documented lint command gets a red result caused entirely by pre-existing content, before any of their own work is evaluated.

### Why it went unnoticed

The `spell-check` job in `.github/workflows/cicd.yaml` is commented out:

```yaml
  # spell-check:
  #   needs: install_modules
  #   runs-on: ubuntu-latest
  #   steps:
  #     - uses: actions/checkout@v4
  #     - uses: ./.github/actions/base-setup
  #       name: Base Setup
  #     - name: Run Spellcheck
  #       run: pnpm run spellcheck:lint
```

`js-lint`, `md-lint`, `format` and `build` all run in CI, so nothing else drifts. Spellcheck is the one gate with no CI enforcement, so new prose lands without the dictionary being updated alongside it, and the failures accumulate.

### Fix

None of the five flagged instances is a typo, so the dictionary is the correct place to resolve them rather than editing the prose:

| Word | Context |
|---|---|
| `Inkworks` | The program that superseded Forge — [ink.works](https://ink.works), linked directly in `forge-program.mdx` |
| `Matrixed` | Part of **Matrixed.Link**, the operator behind BoltRPC in the RPC provider directory |
| `roadmaps` | Ordinary prose in `echo-program.mdx` |
| `tokenomics` | Ordinary prose in `office-hours.mdx` |

Added to `cspell/project-words.txt` in the file'"'"'s existing append order, matching how `Uniblock` was most recently added in #641.

### Verification

Before, on `main`:

```
$ pnpm run spellcheck:lint
CSpell: Files checked: 53, Issues found: 5 in 4 files.
```

After, on this branch:

```
$ pnpm run lint
CSpell: Files checked: 53, Issues found: 0 in 0 files.
$ echo $?
0
```

All four gates (`lint:js`, `lint:mdx`, `format:js:check`, `spellcheck:lint`) pass.

### Note

This only clears the backlog so the local gate is usable again. It does not re-enable the commented-out `spell-check` CI job — that looked like a deliberate call, and re-enabling it is your decision rather than something to slip into a content fix. Happy to send that as a follow-up if you would like it, now that the gate is green and it would pass.
