### PR TITLE
fix(connect-wallet): give each network heading its own anchor id

### DIFF
--- a/src/components/AddNetworkButton.tsx
+++ b/src/components/AddNetworkButton.tsx
@@ -28,8 +28,8 @@ export const AddNetworkButton = ({
           <span>{heading}</span>
           {isSelected && <ConnectedPulse className="size-6" />}
           <a
-            href="#mainnet"
-            id="mainnet"
+            href={`#${network}`}
+            id={network}
             className="subheading-anchor"
             aria-label="Permalink for this section"
           ></a>


### PR DESCRIPTION
### Problem

`AddNetworkButton` takes a `network` prop, but its permalink anchor is hardcoded:

```tsx
<a
  href="#mainnet"
  id="mainnet"
  className="subheading-anchor"
  aria-label="Permalink for this section"
></a>
```

`general/connect-wallet.mdx` renders the component **twice**, once per network:

```mdx
<AddNetworkButton network="mainnet" heading="Mainnet" />

<AddNetworkButton network="sepolia" heading="Testnet (Sepolia)" />
```

So both headings emit the same id. From the built page on `main`:

```
$ grep -o 'id="mainnet"' .next/server/pages/general/connect-wallet.html | wc -l
2
```

```
... Mainnet           <a href="#mainnet" id="mainnet" class="subheading-anchor" ...
... Testnet (Sepolia) <a href="#mainnet" id="mainnet" class="subheading-anchor" ...
```

Three things follow:

1. **The document carries a duplicate id.** That is invalid HTML, and it makes `getElementById` and `:target` resolve to whichever element comes first.
2. **The "Testnet (Sepolia)" permalink navigates to Mainnet.** The control whose whole purpose is linking to a section links to the wrong one.
3. **The testnet section has no anchor at all**, so nothing can link to it.

### Fix

Derive both from the `network` prop:

```tsx
href={`#${network}`}
id={network}
```

Mainnet keeps `#mainnet`, so any existing link or bookmark still resolves, and the testnet heading gets `#sepolia`.

### Verification

Rebuilt and re-checked the same page:

```
id="mainnet": 1
id="sepolia": 1

... Mainnet           <a href="#mainnet" id="mainnet" ...
... Testnet (Sepolia) <a href="#sepolia" id="sepolia" ...
```

One of each, on the correct heading.

`pnpm run build` succeeds. `lint:js`, `lint:mdx` and `format:js:check` all pass. `spellcheck:lint` fails on `main` for unrelated reasons (missing dictionary words) which #661 covers; this change adds nothing to it.

### Note

This is independent of my two other open PRs here (#654, #661) and touches a different file, so they can be merged in any order.
