### PR TITLE
fix(toc): point "Edit this page on GitHub" at the current page

### DIFF
--- a/src/components/Toc.tsx
+++ b/src/components/Toc.tsx
@@ -10,7 +10,12 @@ interface TocProps {
   filePath: string;
 }
 
-export const Toc: React.FC<TocProps> = ({ toc: headings }) => {
+export const Toc: React.FC<TocProps> = ({ toc: headings, filePath }) => {
+  // `filePath` is relative to the project root, e.g. "src/pages/general/rpc.mdx"
+  const editUrl = filePath
+    ? `${URLS.editDocsOnGithubBase}/${filePath}`
+    : URLS.repositoryUrl;
+
   return (
     <div className="flex flex-col items-start justify-start py-5 sticky top-14">
       {headings.length > 0 && (
@@ -31,10 +36,7 @@ export const Toc: React.FC<TocProps> = ({ toc: headings }) => {
         </div>
       )}
       <div className="flex flex-col gap-2">
-        <Link
-          href={URLS.editDocsOnGithub}
-          className="group text-xs flex items-center gap-1"
-        >
+        <Link href={editUrl} className="group text-xs flex items-center gap-1">
           <PencilIcon className="size-4 toc-link" />
           <span className="toc-link">Edit this page on GitHub</span>
         </Link>

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -6,5 +6,5 @@ export const URLS = {
   repositoryUrl: "https://github.com/inkonchain/docs",
   developerWaitlistUrl: "https://inkonchain.com",
   feedbackUrl: "https://inkonchain.com",
-  editDocsOnGithub: "https://github.com/inkonchain",
+  editDocsOnGithubBase: "https://github.com/inkonchain/docs/edit/main",
 };


### PR DESCRIPTION
## Problem

Every page's **"Edit this page on GitHub"** link in the table of contents sends the reader to `https://github.com/inkonchain` — the GitHub *organization* landing page. It never opens the page they were reading, and it does not even land on this repository.

`Toc` already receives what it needs to build the right link. Nextra passes the page's project-root-relative source path as `filePath` (`nextra/dist/server/loader.js`: `filePath: slash(path.relative(CWD, mdxPath))`), and the prop is declared in `TocProps`:

```ts
interface TocProps {
  toc: Heading[];
  filePath: string;
}

export const Toc: React.FC<TocProps> = ({ toc: headings }) => {
```

but it is never destructured, so it is silently dropped. The link then falls back to the constant `URLS.editDocsOnGithub`, which is set to the org URL:

```ts
editDocsOnGithub: "https://github.com/inkonchain",
```

## Fix

Use the prop, and rename the constant to `editDocsOnGithubBase` so its role as a URL prefix is clear:

```ts
editDocsOnGithubBase: "https://github.com/inkonchain/docs/edit/main",
```

```tsx
const editUrl = filePath
  ? `${URLS.editDocsOnGithubBase}/${filePath}`
  : URLS.repositoryUrl;
```

The `filePath` fallback keeps the link sane for any route Nextra renders without a source file (the theme defaults `filePath` to `""`).

Two files, +8/-6. No behaviour outside the edit link changes.

## Verification

Rendered HTML from `next dev`, same page, with and without the patch:

| | href on `/general/connect-wallet` |
|---|---|
| before | `https://github.com/inkonchain` |
| after | `https://github.com/inkonchain/docs/edit/main/src/pages/general/connect-wallet.mdx` |

`pnpm run build` succeeds, and 44 of the pre-rendered pages in `.next/server/pages` now carry a per-page edit URL, e.g.

```
https://github.com/inkonchain/docs/edit/main/src/pages/faq.mdx
https://github.com/inkonchain/docs/edit/main/src/pages/index.mdx
https://github.com/inkonchain/docs/edit/main/src/pages/status.mdx
```

Each resolves (HTTP 200) to GitHub's editor for that file.

`pnpm run lint:js`, `pnpm run format:js:check` and `tsc --noEmit` are clean. `spellcheck:lint` fails on `main` for unrelated reasons — that is covered separately in #661.
